### PR TITLE
Quick fix for current parcel-bundler versions - tested with ^1.12.4

### DIFF
--- a/lib/asset.js
+++ b/lib/asset.js
@@ -17,12 +17,12 @@ class InlineWorkerAsset extends JSAsset {
     // Return JS with inlined Worker
     if (this.isWorkerJs) {
 
-      const code = original[0].value;
+      //const code = original[0].value;
       
       return {
         js: `
           module.exports.init = function() { 
-            const blob = new Blob([${JSON.stringify(code)}], { type: 'text/javascript' });
+            const blob = new Blob([${JSON.stringify(original)}], { type: 'text/javascript' });
             const workerUrl = URL.createObjectURL(blob);
             
             return new Worker(workerUrl) 

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -11,12 +11,13 @@ class InlineWorkerAsset extends JSAsset {
     }
   }
 
-  generate() {
-    const original = super.generate()
+  async generate() {
+    const original = await super.generate()
 
     // Return JS with inlined Worker
     if (this.isWorkerJs) {
-      const code = original.js;
+
+      const code = original[0].value;
       
       return {
         js: `


### PR DESCRIPTION
Well,
Bundling workers as inline assets is a must have in order to distribute a simple script-tag version of a parcel-bundled app that uses workers.

This quick fix works for newest parcel-bundler

